### PR TITLE
feat: allow replacing all instances in a dir

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -90,3 +90,19 @@ Flags:
 Global Flags:
   --config string   config file (default is $HOME/.config/stew/config.yaml)
 ```
+
+## replace
+```
+Replace a string in a project
+
+Usage:
+stew replace <old_string> <new_string> [flags]
+
+Flags:
+  -h, --help          help for replace
+  -p, --path string   The path to the stew (defaults to current directory)
+  -i, --ignore-case   Ignore case when searching for the old string
+
+  Global Flags:
+--config string   config file (default is $HOME/.config/stew/config.yaml)
+```

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ go install github.com/BenjuhminStewart/stew@latest
 - `stew add`: add a new stew template
 - `stew get`: get a stew given a certain id or name
 - `stew list`: list all stew templates
-- `stew remove`: remove a stew template
 - `stew new`: create a new instance of a stew template
+- `stew remove`: remove a stew template
+- `stew replace`: replace a string in a project
 
 For more information on usage, checkout the [DOC.md](https://github.com/BenjuhminStewart/stew/blob/main/DOC.md) file.
 

--- a/cmd/replace/replace.go
+++ b/cmd/replace/replace.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2024 Benjamin Stewart <benjuhminstewart@gmail.com
+*/
+package replace
+
+import (
+	"fmt"
+
+	"github.com/BenjuhminStewart/stew/util"
+	"github.com/spf13/cobra"
+)
+
+const (
+	green      = "\033[32m"
+	red        = "\033[31m"
+	path_color = "\033[33m"
+	quoted     = "\033[35m"
+	reset      = "\033[0m"
+)
+
+// ReplaceCmd represents the replace command
+var ReplaceCmd = &cobra.Command{
+	Use:   "replace",
+	Short: "Replace a project name in a stew",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if len(args) < 2 {
+			cmd.Help()
+			return
+		}
+		old_string := args[0]
+		new_string := args[1]
+
+		path, _ := cmd.Flags().GetString("path")
+		ignore_case, _ := cmd.Flags().GetBool("ignore-case")
+
+		path, err := util.GetPath(path)
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
+
+		if path == "" {
+			path = util.GetCurrentDir()
+		}
+
+		count, err := util.UpdateProjectName(path, old_string, new_string, ignore_case)
+		if err != nil {
+			cmd.Println(err)
+			return
+		}
+
+		fmt.Printf("\nReplaced %v%v%v instances of %v%v%v with %v%v%v\n", green, count, reset, red, old_string, reset, quoted, new_string, reset)
+
+	},
+}
+
+func flags() {
+	ReplaceCmd.Flags().StringP("path", "p", "", "The path to the stew (defaults to current directory)")
+	ReplaceCmd.Flags().BoolP("ignore-case", "i", false, "Whether to replace the string case sensitively")
+}
+
+func init() {
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// replaceCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// replaceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	flags()
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/BenjuhminStewart/stew/cmd/list"
 	"github.com/BenjuhminStewart/stew/cmd/new"
 	"github.com/BenjuhminStewart/stew/cmd/remove"
+	"github.com/BenjuhminStewart/stew/cmd/replace"
 	"github.com/BenjuhminStewart/stew/util"
 )
 
@@ -53,6 +54,8 @@ func addSubCommands() {
 	rootCmd.AddCommand(remove.RemoveCmd)
 	rootCmd.AddCommand(new.NewCmd)
 	rootCmd.AddCommand(get.GetCmd)
+	rootCmd.AddCommand(replace.ReplaceCmd)
+
 }
 
 func init() {


### PR DESCRIPTION
run `stew replace <old_string> <new_string> [flags]` to replace all instances of the old string with the new string in a project

if you want to ignore case, run
`stew replace <old_string> <new_string> [flags]` with the `-i` or `--ignore-case` flag.

if you want to replace in only a specific directory, specify the path with the `-p` or `--path` flag.